### PR TITLE
Map raw unicode symbols to Isabelle sequences

### DIFF
--- a/isar-mode.el
+++ b/isar-mode.el
@@ -399,7 +399,12 @@
     (if (boundp (intern (concat "isar-" (symbol-name var))))
         (set (intern (concat "unicode-tokens-" (symbol-name var) "-variable"))
              (intern (concat "isar-" (symbol-name var))))))
-  (unicode-tokens-initialise))
+  (unicode-tokens-initialise)
+  ;; Map raw unicode to equivalent Isabelle sequences.
+  (cl-loop for (token beautified)
+           in (cl-concatenate 'list isar-symbols-tokens isar-extended-symbols-tokens isar-symbols-tokens)
+	         do (define-key isar-mode-map (kbd beautified) (format "\\<%s>" token)))
+)
 
 (defvar isar-name "isar"
   "Name of isar mode.")


### PR DESCRIPTION
Fixes m-fleury/isabelle-emacs#79. This should work on all emacs flavors (Doom emacs, Spacemacs, Centaur emacs, Emacs vanilla, …).